### PR TITLE
feat: Add Unload LLM Model node to free VRAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Minimal version focused on **role-based dialogue observation**.
 
 ### Unload LLM Model
 A utility node to manually unload the LLM from VRAM. Useful for freeing up GPU memory for other tasks without restarting ComfyUI.
+This node can be executed as an output node.
 Usage: set `unload_now` to true and queue the node to unload the model.
 After running, set it back to false to avoid accidental repeated unloads.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Model-to-model dialogue execution without graph cycles.
 ### LLM Dialogue Cycle (Simple)
 Minimal version focused on **role-based dialogue observation**.
 
+### Unload LLM Model
+A utility node to manually unload the LLM from VRAM. Useful for freeing up GPU memory for other tasks without restarting ComfyUI.
+Usage: set `unload_now` to true and queue the node to unload the model.
+After running, set it back to false to avoid accidental repeated unloads.
+
 ---
 
 ## Key Design Concepts
@@ -312,4 +317,3 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 - Improved Qwen3.5 generation paths and override handling
 - Improved backward compatibility for repetition-control parameters
 - Improved conversation summarization quality and history tracking
-

--- a/llm_session_nodes.py
+++ b/llm_session_nodes.py
@@ -22,8 +22,6 @@ import shutil
 import folder_paths
 import hashlib
 import traceback
-
-
 # ============================================================================
 # Simple Defaults (config-driven)
 # ============================================================================
@@ -1952,6 +1950,12 @@ class GGUFModelManager:
             print(f"[GGUFModelManager] Unloading model: {self.current_model_path}")
         try:
             if self.model is not None:
+                # Detach any runtime/persistent cache (RAM/Trie/Disk) from llama-cpp
+                try:
+                    self.invalidate_cache(self.model, remove_disk_data=False)
+                except Exception:
+                    pass
+            if self.model is not None:
                 del self.model
         finally:
             self.model = None
@@ -1965,10 +1969,24 @@ class GGUFModelManager:
         self.current_model_path = None
         self.current_mmproj_path = None
         self._signature = None
+        try:
+            # Clear in-memory KV cache state to avoid stale session reuse.
+            global _MEM_KV_STATE
+            _MEM_KV_STATE.clear()
+        except Exception:
+            pass
 
         # Encourage timely cleanup (important for llama-cpp backends and mmproj state)
         import gc as _gc
         _gc.collect()
+        try:
+            import torch as _torch
+            if _torch.cuda.is_available():
+                _torch.cuda.empty_cache()
+            if hasattr(_torch, "xpu") and _torch.xpu.is_available():
+                _torch.xpu.empty_cache()
+        except Exception:
+            pass
 
 # Global model manager
 _model_manager = GGUFModelManager()
@@ -3963,6 +3981,36 @@ class LLMDialogueCycleNode:
         return ("\n".join(transcript_lines),)
 
 
+class UnloadLLMModelNode:
+    """Node to unload the currently loaded LLM model to free VRAM."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "unload_now": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": "Toggle true and queue to unload the current LLM model and free VRAM."
+                }),
+            },
+            "optional": {
+                "trigger": ("*",),
+            },
+        }
+
+    RETURN_TYPES = ("*",)
+    RETURN_NAMES = ("trigger",)
+    FUNCTION = "unload_model"
+    CATEGORY = "LLM/Session"
+
+    def unload_model(self, unload_now: bool, trigger: Any = None):
+        """Calls the global model manager to unload the model."""
+        global _model_manager
+        if unload_now and _model_manager:
+            _model_manager.unload_model()
+        return (trigger,)
+
+
 # ============================================================================
 # ComfyUI Node Registration
 # ============================================================================
@@ -3972,6 +4020,7 @@ NODE_CLASS_MAPPINGS = {
     "LLMDialogueCycleSimpleNode": LLMDialogueCycleSimpleNode,
     "LLMSessionChatNode": LLMSessionChatNode,
     "LLMDialogueCycleNode": LLMDialogueCycleNode,
+    "UnloadLLMModelNode": UnloadLLMModelNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -3979,6 +4028,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "LLMDialogueCycleSimpleNode": "LLM Dialogue Cycle (Simple)",
     "LLMSessionChatNode": "LLM Session Chat",
     "LLMDialogueCycleNode": "LLM Dialogue Cycle",
+    "UnloadLLMModelNode": "Unload LLM Model",
 }
 
 

--- a/llm_session_nodes.py
+++ b/llm_session_nodes.py
@@ -1512,6 +1512,7 @@ class GGUFModelManager:
         self._signature: Optional[tuple] = None
         self.current_model_path: Optional[str] = None
         self.current_mmproj_path: Optional[str] = None
+        self._suppress_next_unload_log: bool = False
 
         # Optional override for where cache should be stored
         self.cache_dir_override: Optional[str] = None
@@ -1704,7 +1705,9 @@ class GGUFModelManager:
 
         # Otherwise, explicitly unload to avoid stale mmproj/handler state
         if self.model is not None:
-            print("[GGUFModelManager] Signature changed -> unloading previous model to avoid stale state")
+            if not self._suppress_next_unload_log:
+                print("[GGUFModelManager] Signature changed -> unloading previous model to avoid stale state")
+            self._suppress_next_unload_log = False
             self.unload_model()
 
         print(f"[GGUFModelManager] Loading model: {model_path}")
@@ -4002,11 +4005,16 @@ class UnloadLLMModelNode:
     RETURN_NAMES = ("trigger",)
     FUNCTION = "unload_model"
     CATEGORY = "LLM/Session"
+    OUTPUT_NODE = True
 
     def unload_model(self, unload_now: bool, trigger: Any = None):
         """Calls the global model manager to unload the model."""
         global _model_manager
         if unload_now and _model_manager:
+            # Suppress only if an actual model was present to unload.
+            if _model_manager.model is not None:
+                model_path = _model_manager.current_model_path or "unknown"
+                _model_manager._suppress_next_unload_log = True
             _model_manager.unload_model()
         return (trigger,)
 


### PR DESCRIPTION
Resolves #3

This commit introduces a new "Unload LLM Model" node to address an issue where language models would persist in VRAM, preventing users from loading other models without restarting ComfyUI.

The new node, when triggered, unloads the active LLM and calls the appropriate cache clearing function (`torch.cuda.empty_cache()` for CUDA and `torch.xpu.empty_cache()` for Sycl/XPU) to free up GPU memory.

This allows for more flexible memory management within ComfyUI, enabling users to switch between different types of models in a single session.

The README has also been updated with instructions for the new node.