### PR TITLE
Add tensor_split support for llama.cpp GPU selection

### DIFF
--- a/PARAMETERS.md
+++ b/PARAMETERS.md
@@ -60,6 +60,35 @@ Recommended usage:
 
 ---
 
+### tensor_split
+Advanced Simple-node setting for multi-GPU llama.cpp / llama-cpp-python environments.
+
+This setting is read from `config/simple_defaults.json` only. Leave it as `null` or omit it to use the llama.cpp default behavior.
+
+Examples:
+
+```json
+"tensor_split": [1.0, 0.0]
+```
+
+2 visible GPUs:
+- `[1.0, 0.0]`: use GPU 0 for llama.cpp model offload
+- `[0.0, 1.0]`: use GPU 1 for llama.cpp model offload
+- `[1.0, 1.0]`: split across GPU 0 and GPU 1
+
+3 visible GPUs:
+- `[1.0, 0.0, 0.0]`: use GPU 0
+- `[0.0, 1.0, 0.0]`: use GPU 1
+- `[0.0, 0.0, 1.0]`: use GPU 2
+- `[1.0, 1.0, 1.0]`: split across all three GPUs
+
+Notes:
+- `tensor_split` applies to GPUs visible to the current ComfyUI process.
+- If `CUDA_VISIBLE_DEVICES` is set, physical GPU numbers may differ from the internal GPU order. For example, `CUDA_VISIBLE_DEVICES=1,0` makes physical GPU 1 appear as internal GPU 0.
+- `n_gpu_layers` must be greater than `0` or `-1` for GPU offload to happen.
+
+---
+
 ### temperature / top_p
 Sampling parameters controlling randomness.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ When using Vision-capable models, please follow these rules:
 - **config_path**: Optional JSON file to override internal defaults in Simple nodes.
 - **force_text_only** (Dialogue Cycle Simple): Forces pure text mode to avoid mmproj / vision handler differences and improve reproducibility.
 - **reset_session** (Dialogue Cycle Simple): Overwrites the history and summary files associated with the session name, and resets per-session KV state. The session's disk cache is kept.
+- **tensor_split** (`config/simple_defaults.json`): Optional llama.cpp multi-GPU split. For example, `"tensor_split": [1.0, 0.0]` keeps llama.cpp model offload on visible GPU 0 in a 2-GPU setup. Leave it `null` or omit it for default behavior.
 
 ### Cache Scope Notes
 

--- a/config/simple_defaults.json
+++ b/config/simple_defaults.json
@@ -5,6 +5,7 @@
   "temperature": 0.7,
   "top_p": 0.9,
   "n_gpu_layers": 0,
+  "tensor_split": null,
   "n_ctx": 4096,
   "max_turns": 6,
   "summarize_old_history": true,

--- a/core/defaults.py
+++ b/core/defaults.py
@@ -16,6 +16,7 @@ SIMPLE_DEFAULTS: Dict[str, Any] = {
     "temperature": 0.7,
     "top_p": 0.9,
     "n_gpu_layers": 0,
+    "tensor_split": None,
     "n_ctx": 4096,
     "max_turns": 6,
     "summarize_old_history": True,

--- a/core/kv_state.py
+++ b/core/kv_state.py
@@ -19,6 +19,7 @@ def build_kv_state_signature(
     mmproj_path: Optional[str],
     n_ctx: int,
     n_gpu_layers: int,
+    tensor_split: Optional[list[float]] = None,
     get_context_turns: Callable[..., Any],
 ) -> str:
     turns_ctx = get_context_turns(history, max_turns=max_turns)
@@ -32,6 +33,7 @@ def build_kv_state_signature(
             "mmproj_path": os.path.abspath(mmproj_path) if mmproj_path else "",
             "n_ctx": int(n_ctx) if n_ctx is not None else None,
             "n_gpu_layers": int(n_gpu_layers) if n_gpu_layers is not None else None,
+            "tensor_split": [float(x) for x in tensor_split] if tensor_split is not None else None,
             "system": effective_system,
             "summary": summary_txt,
             "turns": turns_ctx,

--- a/llm_session_nodes.py
+++ b/llm_session_nodes.py
@@ -142,6 +142,27 @@ def _normalize_config_path(config_path: Optional[str]) -> str:
     except Exception:
         return raw
 
+def _normalize_tensor_split(value: Any) -> Optional[List[float]]:
+    """Return a llama.cpp tensor_split list, or None when unset/invalid."""
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        return None
+
+    split: List[float] = []
+    for item in value:
+        try:
+            f = float(item)
+        except Exception:
+            return None
+        if f < 0:
+            return None
+        split.append(f)
+
+    if not split or not any(x > 0 for x in split):
+        return None
+    return split
+
 def _simple_config_path() -> str:
     try:
         base = Path(__file__).parent
@@ -228,6 +249,7 @@ def _load_simple_defaults(config_path: Optional[str] = None) -> Dict[str, Any]:
     defaults["max_tokens"] = max(1, _as_int(defaults.get("max_tokens"), _SIMPLE_DEFAULTS_BUILTIN["max_tokens"]))
     defaults["n_ctx"] = max(512, _as_int(defaults.get("n_ctx"), _SIMPLE_DEFAULTS_BUILTIN["n_ctx"]))
     defaults["n_gpu_layers"] = _as_int(defaults.get("n_gpu_layers"), _SIMPLE_DEFAULTS_BUILTIN["n_gpu_layers"])
+    defaults["tensor_split"] = _normalize_tensor_split(defaults.get("tensor_split"))
     defaults["max_turns"] = max(0, _as_int(defaults.get("max_turns"), _SIMPLE_DEFAULTS_BUILTIN["max_turns"]))
     defaults["summary_chunk_turns"] = max(1, _as_int(defaults.get("summary_chunk_turns"), _SIMPLE_DEFAULTS_BUILTIN["summary_chunk_turns"]))
     defaults["max_tokens_summary"] = max(16, _as_int(defaults.get("max_tokens_summary"), _SIMPLE_DEFAULTS_BUILTIN["max_tokens_summary"]))
@@ -328,6 +350,7 @@ def _build_dialogue_cycle_simple_chat_kwargs(
         "temperature": float(defaults["temperature"]),
         "top_p": float(defaults["top_p"]),
         "n_gpu_layers": int(defaults["n_gpu_layers"]),
+        "tensor_split": defaults.get("tensor_split"),
         "n_ctx": int(defaults["n_ctx"]),
         "max_turns": int(defaults["max_turns"]),
         "summarize_old_history": bool(defaults["summarize_old_history"]),
@@ -365,6 +388,7 @@ def _build_session_chat_simple_chat_kwargs(
         "temperature": float(defaults["temperature"]),
         "top_p": float(defaults["top_p"]),
         "n_gpu_layers": int(defaults["n_gpu_layers"]),
+        "tensor_split": defaults.get("tensor_split"),
         "n_ctx": int(defaults["n_ctx"]),
         "max_turns": int(defaults["max_turns"]),
         "summarize_old_history": bool(defaults["summarize_old_history"]),
@@ -1736,6 +1760,7 @@ class GGUFModelManager:
         mmproj_path: Optional[str],
         n_ctx: int,
         n_gpu_layers: int,
+        tensor_split: Optional[List[float]],
         use_vision: bool,
         chat_handler_kwargs: Optional[Dict[str, Any]] = None,
     ) -> tuple:
@@ -1744,6 +1769,7 @@ class GGUFModelManager:
             self._normalize_path(mmproj_path),
             int(n_ctx),
             int(n_gpu_layers),
+            tuple(float(x) for x in tensor_split) if tensor_split is not None else None,
             bool(use_vision),
             json.dumps(chat_handler_kwargs or {}, sort_keys=True, ensure_ascii=True),
         )
@@ -1754,6 +1780,7 @@ class GGUFModelManager:
         mmproj_path: Optional[str] = None,
         n_ctx: int = 4096,
         n_gpu_layers: int = 0,
+        tensor_split: Optional[List[float]] = None,
         chat_handler_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         verbose: bool = False,
     ) -> Llama:
@@ -1761,6 +1788,7 @@ class GGUFModelManager:
         _require_llama_cpp_available()
 
         model_path = self._normalize_path(model_path)
+        tensor_split = _normalize_tensor_split(tensor_split)
 
         # If user explicitly selected "(Not required)", force text-only.
         force_no_mmproj = (mmproj_path == _MMPROJ_NOT_REQUIRED)
@@ -1828,6 +1856,7 @@ class GGUFModelManager:
             mmproj_path=mmproj_path,
             n_ctx=n_ctx,
             n_gpu_layers=n_gpu_layers,
+            tensor_split=tensor_split,
             use_vision=use_vision,
             chat_handler_kwargs=active_chat_handler_kwargs,
         )
@@ -1844,32 +1873,37 @@ class GGUFModelManager:
 
         print(f"[GGUFModelManager] Loading model: {model_path}")
         print(f"[GGUFModelManager] n_ctx={n_ctx}, n_gpu_layers={n_gpu_layers}")
+        if tensor_split is not None:
+            print(f"[GGUFModelManager] tensor_split={tensor_split}")
 
         # Store handler on manager (used later to decide if images are supported)
         self.chat_handler = chat_handler
         self.chat_format = chat_format
 
         # Model loading
+        llama_kwargs: Dict[str, Any] = {
+            "model_path": model_path,
+            "n_ctx": n_ctx,
+            "n_gpu_layers": n_gpu_layers,
+            "verbose": verbose,
+        }
+        if tensor_split is not None:
+            llama_kwargs["tensor_split"] = tensor_split
+
         if use_vision and self.chat_handler is not None:
             print("[GGUFModelManager] Loading with vision support")
             self.model = Llama(
-                model_path=model_path,
+                **llama_kwargs,
                 chat_handler=self.chat_handler,
-                n_ctx=n_ctx,
-                n_gpu_layers=n_gpu_layers,
                 chat_format=self.chat_format,
-                verbose=verbose,
                 # Vision models often need this; safe default for vision path.
                 logits_all=True,
             )
         else:
             print("[GGUFModelManager] Loading in text-only mode")
             self.model = Llama(
-                model_path=model_path,
-                n_ctx=n_ctx,
-                n_gpu_layers=n_gpu_layers,
+                **llama_kwargs,
                 # chat_format=self.chat_format,
-                verbose=verbose,
             )
 
         self.current_model_path = model_path
@@ -1896,7 +1930,14 @@ class GGUFModelManager:
             pass
         return f"llama_cpp_py={pkg_ver}|llama_cpp_backend={backend_ver}"
 
-    def _default_cache_dir(self, model_path: str, mmproj_path: str, n_ctx: int, n_gpu_layers: int = 0) -> str:
+    def _default_cache_dir(
+        self,
+        model_path: str,
+        mmproj_path: str,
+        n_ctx: int,
+        n_gpu_layers: int = 0,
+        tensor_split: Optional[List[float]] = None,
+    ) -> str:
         """
         Compute a stable cache directory for cache data.
         Cache root can be scoped by session; under that root, we key by model settings
@@ -1907,6 +1948,7 @@ class GGUFModelManager:
         key_src = (
             f"{os.path.abspath(model_path)}|{os.path.abspath(mmproj_path or '')}|"
             f"n_ctx={int(n_ctx)}|n_gpu_layers={int(n_gpu_layers)}|"
+            f"tensor_split={json.dumps(tensor_split or [], sort_keys=True)}|"
             f"chat_format={self.chat_format or ''}|use_vision={bool(self.chat_handler is not None)}|"
             f"{self._runtime_cache_fingerprint()}"
         )
@@ -1922,6 +1964,7 @@ class GGUFModelManager:
         mmproj_path: str,
         n_ctx: int,
         n_gpu_layers: int = 0,
+        tensor_split: Optional[List[float]] = None,
         persistent_cache: str = _FULL_UI_SESSION_CHAT_DEFAULTS["persistent_cache"],
         runtime_cache: str = _FULL_UI_SESSION_CHAT_DEFAULTS["runtime_cache"],
     ) -> None:
@@ -1973,7 +2016,13 @@ class GGUFModelManager:
             persistent_obj = None
             persistent_desc = _PERSISTENT_CACHE_OPTIONS[1]
             if persistent_cache == _PERSISTENT_CACHE_OPTIONS[0]:
-                cache_dir = self._default_cache_dir(model_path, mmproj_path, n_ctx, n_gpu_layers=n_gpu_layers)
+                cache_dir = self._default_cache_dir(
+                    model_path,
+                    mmproj_path,
+                    n_ctx,
+                    n_gpu_layers=n_gpu_layers,
+                    tensor_split=tensor_split,
+                )
                 disk_dir = cache_dir
                 if hasattr(llama_cpp, "LlamaDiskCache"):
                     persistent_obj = llama_cpp.LlamaDiskCache(cache_dir)
@@ -2781,6 +2830,7 @@ def _build_dialogue_cycle_common_turn_kwargs(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     max_turns: int,
     summarize_old_history: bool,
@@ -2805,6 +2855,7 @@ def _build_dialogue_cycle_common_turn_kwargs(
         "temperature": temperature,
         "top_p": top_p,
         "n_gpu_layers": n_gpu_layers,
+        "tensor_split": tensor_split,
         "n_ctx": n_ctx,
         "max_turns": max_turns,
         "summarize_old_history": summarize_old_history,
@@ -2841,6 +2892,7 @@ def _build_session_chat_turn_kwargs(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     image: Any,
     max_turns: int,
@@ -2875,6 +2927,7 @@ def _build_session_chat_turn_kwargs(
         "temperature": temperature,
         "top_p": top_p,
         "n_gpu_layers": n_gpu_layers,
+        "tensor_split": tensor_split,
         "n_ctx": n_ctx,
         "image": image,
         "max_turns": max_turns,
@@ -2961,6 +3014,7 @@ def _build_session_chat_node_execution_request(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     image: Any,
     max_turns: int,
@@ -2996,6 +3050,7 @@ def _build_session_chat_node_execution_request(
             temperature=temperature,
             top_p=top_p,
             n_gpu_layers=n_gpu_layers,
+            tensor_split=tensor_split,
             n_ctx=n_ctx,
             image=image,
             max_turns=max_turns,
@@ -3058,6 +3113,7 @@ def _execute_session_chat_turn(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     image: Any,
     max_turns: Optional[int],
@@ -3094,6 +3150,7 @@ def _execute_session_chat_turn(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         image=image,
         max_turns=max_turns,
@@ -3132,6 +3189,7 @@ def _execute_dialogue_cycle_turn(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     max_turns: Optional[int],
     summarize_old_history: bool,
@@ -3167,6 +3225,7 @@ def _execute_dialogue_cycle_turn(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         image=None,
         max_turns=max_turns,
@@ -3205,6 +3264,7 @@ def _run_session_chat_from_inputs(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     image: Any,
     max_turns: int,
@@ -3238,6 +3298,7 @@ def _run_session_chat_from_inputs(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         image=image,
         max_turns=max_turns,
@@ -3321,6 +3382,7 @@ class LLMSessionChatNode:
              history_dir: str = "",
              reset_session: bool = _FULL_UI_SESSION_CHAT_DEFAULTS["reset_session"],
              stream_to_console: bool = _FULL_UI_SESSION_CHAT_DEFAULTS["stream_to_console"],
+             tensor_split: Optional[List[float]] = None,
              chat_handler_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
              text_chat_builder_overrides: Optional[Dict[str, Dict[str, Any]]] = None) -> tuple:
         return _run_session_chat_from_inputs(
@@ -3333,6 +3395,7 @@ class LLMSessionChatNode:
             temperature=temperature,
             top_p=top_p,
             n_gpu_layers=n_gpu_layers,
+            tensor_split=tensor_split,
             n_ctx=n_ctx,
             image=image,
             max_turns=max_turns,
@@ -3373,6 +3436,7 @@ def _chat_one_turn(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     max_turns: int = _FULL_UI_DIALOGUE_CYCLE_DEFAULTS["max_turns"],
     summarize_old_history: bool = _FULL_UI_DIALOGUE_CYCLE_DEFAULTS["summarize_old_history"],
@@ -3413,6 +3477,7 @@ def _chat_one_turn(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         max_turns=max_turns,
         summarize_old_history=summarize_old_history,
@@ -3460,6 +3525,7 @@ def _run_dialogue_cycle_from_inputs(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     max_turns: int,
     summarize_old_history: bool,
@@ -3497,6 +3563,7 @@ def _run_dialogue_cycle_from_inputs(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         max_turns=max_turns,
         summarize_old_history=summarize_old_history,
@@ -3545,6 +3612,7 @@ def _build_dialogue_cycle_node_execution_request(
     temperature: float,
     top_p: float,
     n_gpu_layers: int,
+    tensor_split: Optional[List[float]],
     n_ctx: int,
     max_turns: int,
     summarize_old_history: bool,
@@ -3582,6 +3650,7 @@ def _build_dialogue_cycle_node_execution_request(
         temperature=temperature,
         top_p=top_p,
         n_gpu_layers=n_gpu_layers,
+        tensor_split=tensor_split,
         n_ctx=n_ctx,
         max_turns=max_turns,
         summarize_old_history=summarize_old_history,
@@ -3663,6 +3732,7 @@ class LLMDialogueCycleNode:
         history_dir: str = "",
         reset_session: bool = _FULL_UI_DIALOGUE_CYCLE_DEFAULTS["reset_session"],
         stream_to_console: bool = _FULL_UI_DIALOGUE_CYCLE_DEFAULTS["stream_to_console"],
+        tensor_split: Optional[List[float]] = None,
         chat_handler_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         text_chat_builder_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> tuple:
@@ -3681,6 +3751,7 @@ class LLMDialogueCycleNode:
             temperature=temperature,
             top_p=top_p,
             n_gpu_layers=n_gpu_layers,
+            tensor_split=tensor_split,
             n_ctx=n_ctx,
             max_turns=max_turns,
             summarize_old_history=summarize_old_history,

--- a/services/chat_turn_service.py
+++ b/services/chat_turn_service.py
@@ -46,6 +46,7 @@ class DialogueCycleNodeExecutionRequest:
     temperature: float
     top_p: float
     n_gpu_layers: int
+    tensor_split: Optional[List[float]]
     n_ctx: int
     max_turns: int
     summarize_old_history: bool
@@ -89,6 +90,7 @@ class DialogueCycleNodeExecutionService:
             temperature=request.temperature,
             top_p=request.top_p,
             n_gpu_layers=request.n_gpu_layers,
+            tensor_split=request.tensor_split,
             n_ctx=request.n_ctx,
             max_turns=request.max_turns,
             summarize_old_history=request.summarize_old_history,
@@ -262,7 +264,6 @@ class ChatTurnService:
                     pass
 
         return "\n".join(transcript_lines)
-
 
 
 

--- a/services/kv_state_service.py
+++ b/services/kv_state_service.py
@@ -46,6 +46,7 @@ class KvStateService:
                     mmproj_path=mmproj_path,
                     n_ctx=int(request.n_ctx),
                     n_gpu_layers=int(request.n_gpu_layers),
+                    tensor_split=getattr(request, "tensor_split", None),
                     get_context_turns=get_context_turns,
                 )
                 try_restore_kv_state(
@@ -100,6 +101,7 @@ class KvStateService:
                 mmproj_path=mmproj_path,
                 n_ctx=int(request.n_ctx),
                 n_gpu_layers=int(request.n_gpu_layers),
+                tensor_split=getattr(request, "tensor_split", None),
                 get_context_turns=get_context_turns,
             )
             try_save_kv_state = self._dep(deps, "try_save_kv_state")

--- a/services/turn_execution_service.py
+++ b/services/turn_execution_service.py
@@ -76,6 +76,7 @@ class TurnExecutionRequest:
     top_p: float
     n_gpu_layers: int
     n_ctx: int
+    tensor_split: Optional[List[float]] = None
     image: Any = None
     max_turns: Optional[int] = 12
     summarize_old_history: bool = True
@@ -127,6 +128,7 @@ class TurnExecutionRequest:
         top_p: float,
         n_gpu_layers: int,
         n_ctx: int,
+        tensor_split: Optional[List[float]] = None,
         image: Any,
         max_turns: Optional[int],
         summarize_old_history: bool,
@@ -169,6 +171,7 @@ class TurnExecutionRequest:
             top_p=float(top_p),
             n_gpu_layers=int(n_gpu_layers),
             n_ctx=int(n_ctx),
+            tensor_split=(list(tensor_split) if tensor_split is not None else None),
             image=image,
             max_turns=(int(max_turns) if max_turns is not None else None),
             summarize_old_history=bool(summarize_old_history),
@@ -346,8 +349,9 @@ class TurnExecutionService:
         mmproj_path: Optional[str],
         n_ctx: int,
         n_gpu_layers: int,
+        tensor_split: Optional[List[float]] = None,
     ) -> Dict[str, Any]:
-        return {
+        model_sig = {
             "model_file": os.path.basename(model_path),
             "mmproj_file": (
                 os.path.basename(mmproj_path)
@@ -357,6 +361,9 @@ class TurnExecutionService:
             "n_ctx": int(n_ctx),
             "n_gpu_layers": int(n_gpu_layers),
         }
+        if tensor_split is not None:
+            model_sig["tensor_split"] = [float(x) for x in tensor_split]
+        return model_sig
 
     def _load_history(
         self,
@@ -433,6 +440,7 @@ class TurnExecutionService:
                 mmproj_path=mmproj_path,
                 n_ctx=int(request.n_ctx),
                 n_gpu_layers=int(request.n_gpu_layers),
+                tensor_split=request.tensor_split,
                 chat_handler_overrides=request.chat_handler_overrides,
                 verbose=False,
             )
@@ -454,6 +462,7 @@ class TurnExecutionService:
                 mmproj_path=mmproj_path,
                 n_ctx=int(request.n_ctx),
                 n_gpu_layers=int(request.n_gpu_layers),
+                tensor_split=request.tensor_split,
                 persistent_cache=request.persistent_cache,
                 runtime_cache=request.runtime_cache,
             )
@@ -580,6 +589,7 @@ class TurnExecutionService:
             mmproj_path=mmproj_path,
             n_ctx=int(request.n_ctx),
             n_gpu_layers=int(request.n_gpu_layers),
+            tensor_split=request.tensor_split,
         )
         history, hist_path = self._load_history(request=request, deps=deps, model_sig=model_sig)
         clear_kv_state_for_session = self._reset_state_if_needed(request=request, deps=deps, mgr=mgr)

--- a/tests/services/test_chat_turn_service.py
+++ b/tests/services/test_chat_turn_service.py
@@ -217,6 +217,7 @@ def test_dialogue_cycle_node_execution_service_builds_and_runs() -> None:
         temperature=0.7,
         top_p=0.9,
         n_gpu_layers=0,
+        tensor_split=None,
         n_ctx=1024,
         max_turns=12,
         summarize_old_history=True,
@@ -312,6 +313,7 @@ def test_dialogue_cycle_node_execution_service_passes_model_and_mmproj() -> None
         temperature=0.7,
         top_p=0.9,
         n_gpu_layers=0,
+        tensor_split=None,
         n_ctx=1024,
         max_turns=12,
         summarize_old_history=True,
@@ -407,4 +409,3 @@ def test_run_dialogue_cycle_llama_trie_cache_skips_all_unload() -> None:
 
     assert unload_calls.count("A") == 0
     assert unload_calls.count("B") == 0
-

--- a/tests/test_tensor_split_config.py
+++ b/tests/test_tensor_split_config.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+
+
+def _load_nodes_module(monkeypatch):
+    fake_folder_paths = types.SimpleNamespace(
+        models_dir="C:/models",
+        get_folder_paths=lambda _key: [],
+        get_filename_list=lambda _key: [],
+        get_output_directory=lambda: "C:/output",
+    )
+    monkeypatch.setitem(sys.modules, "folder_paths", fake_folder_paths)
+    sys.modules.pop("llm_session_nodes", None)
+    return importlib.import_module("llm_session_nodes")
+
+
+def test_simple_defaults_accept_tensor_split(monkeypatch, tmp_path):
+    module = _load_nodes_module(monkeypatch)
+    config_path = tmp_path / "simple_defaults.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "n_gpu_layers": -1,
+                "tensor_split": [1.0, 0.0],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    defaults = module._load_simple_defaults(str(config_path))
+
+    assert defaults["tensor_split"] == [1.0, 0.0]
+
+
+def test_simple_defaults_ignore_invalid_tensor_split(monkeypatch, tmp_path):
+    module = _load_nodes_module(monkeypatch)
+    config_path = tmp_path / "simple_defaults.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "tensor_split": [0.0, 0.0],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    defaults = module._load_simple_defaults(str(config_path))
+
+    assert defaults["tensor_split"] is None
+
+
+def test_model_manager_passes_tensor_split_to_llama(monkeypatch):
+    module = _load_nodes_module(monkeypatch)
+    calls = []
+
+    class DummyLlama:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(module, "LLAMA_CPP_AVAILABLE", True)
+    monkeypatch.setattr(module, "Llama", DummyLlama)
+
+    manager = module.GGUFModelManager()
+    manager.load_model(
+        model_path="C:/models/test.gguf",
+        mmproj_path=module._MMPROJ_NOT_REQUIRED,
+        n_ctx=1024,
+        n_gpu_layers=-1,
+        tensor_split=[1.0, 0.0],
+    )
+
+    assert calls[0]["tensor_split"] == [1.0, 0.0]


### PR DESCRIPTION
This draft PR adds optional `tensor_split` support via `config/simple_defaults.json`.

Example:

```json
"tensor_split": [1.0, 0.0]
```

This allows users to keep llama.cpp model offload on a selected visible GPU in multi-GPU environments.

Notes:
- `tensor_split` is only applied when configured.
- `null` or omitted keeps the existing default behavior.
- GPU indexes follow the devices visible to the ComfyUI process.